### PR TITLE
Add configurations for LocalStack CI integration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,12 +23,32 @@ inputs:
     description: 'Configuration variables to use for LocalStack'
     required: false
     default: ''
+  ci-project:
+    description: 'Name of the CI project to track in LocalStack Cloud'
+    required: false
+    default: ''
+  github-token:
+    description: 'Github token used to create PR comments'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
   steps:
-    - 
-      run: |
+    - name: Prepare LocalStack Build
+      uses: LocalStack/setup-localstack/prepare@pr-integration
+      if: inputs.ci-project && inputs.github-token
+      with:
+        github-token: ${{ inputs.github-token }}
+        ci-project: ${{ inputs.ci-project }}
+    - name: Finish LocalStack Build
+      uses: LocalStack/setup-localstack/finish@pr-integration
+      if: inputs.github-token
+      with:
+        github-token: ${{ inputs.github-token }}
+        ci-project: ${{ inputs.ci-project }}
+
+    - run: |
         pip install pyopenssl -U
 
         if [ "$USE_PRO" = true ]; then

--- a/action.yml
+++ b/action.yml
@@ -35,36 +35,35 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Prepare LocalStack Build
-      uses: LocalStack/setup-localstack/prepare@pr-integration
+    - name: Initial PR comment
+      # TODO: potentially replace with Action version number over time
+      uses: LocalStack/setup-localstack/prepare@main
       if: inputs.ci-project && inputs.github-token
       with:
         github-token: ${{ inputs.github-token }}
         ci-project: ${{ inputs.ci-project }}
-    - name: Finish LocalStack Build
-      uses: LocalStack/setup-localstack/finish@pr-integration
-      if: inputs.github-token
-      with:
-        github-token: ${{ inputs.github-token }}
-        ci-project: ${{ inputs.ci-project }}
 
-    - run: |
+    - name: Start LocalStack
+      run: |
         pip install pyopenssl -U
 
         if [ "$USE_PRO" = true ]; then
-          docker pull localstack/localstack-pro:"$IMAGE_TAG"
+          docker pull localstack/localstack-pro:"$IMAGE_TAG" &
           CONFIGURATION="$CONFIGURATION DNS_ADDRESS=0"
         else
-          docker pull localstack/localstack:"$IMAGE_TAG"
+          docker pull localstack/localstack:"$IMAGE_TAG" &
         fi
 
         pip install localstack
-        eval "${CONFIGURATION} localstack start -d"
-
-        localstack wait -t 30
         if [ "$INSTALL_AWSLOCAL" = true ]; then
           pip install awscli-local[ver1]
         fi
+
+        export CI_PROJECT=${{ inputs.ci-project }}
+        eval "${CONFIGURATION} localstack start -d"
+
+        localstack wait -t 30
+
       shell: bash
       env:
         IMAGE_TAG: "${{ inputs.image-tag }}"

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -1,11 +1,5 @@
 name: Finish CI Build
 
-on:
-  workflow_run:
-    workflows: ["Run CI Tests"]
-    types:
-      - completed
-
 inputs:
   github-token:
     description: 'Github token used to create PR comments'
@@ -17,7 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     - name: Download PR artifact
       uses: dawidd6/action-download-artifact@v2
       with:
@@ -38,22 +31,3 @@ runs:
           <!-- Sticky Pull Request Comment -->
         body-include: '<!-- Sticky Pull Request Comment -->'
         number: ${{ steps.pr.outputs.pr_id }}
-
-  # failed:
-  #   runs-on: ubuntu-latest
-  #   if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
-  #   steps:
-  #
-  #     - name: Save the PR ID
-  #       id: pr
-  #       run: echo "::set-output name=id::$(<pr-id.txt)"
-  #
-  #     - name: Job failure
-  #       uses: actions-cool/maintain-one-comment@v3.1.1
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         body: |
-  #           Deploy PR Preview failed.
-  #           <!-- Sticky Pull Request Comment -->
-  #         body-include: '<!-- Sticky Pull Request Comment -->'
-  #         number: ${{ steps.pr.outputs.id }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -1,0 +1,51 @@
+name: Finish CI Build
+
+on:
+  workflow_run:
+    workflows: ["Run CI Tests"]
+    types:
+      - completed
+
+jobs:
+  success:
+    runs-on: ubuntu-latest
+    # if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download PR artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: pr
+
+      - name: Load the PR ID
+        id: pr
+        run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
+
+      - name: Update status comment
+        uses: actions-cool/maintain-one-comment@v3.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci
+            <!-- Sticky Pull Request Comment -->
+          body-include: '<!-- Sticky Pull Request Comment -->'
+          number: ${{ steps.pr.outputs.pr_id }}
+
+  # failed:
+  #   runs-on: ubuntu-latest
+  #   if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'failure'
+  #   steps:
+  #
+  #     - name: Save the PR ID
+  #       id: pr
+  #       run: echo "::set-output name=id::$(<pr-id.txt)"
+  #
+  #     - name: Job failure
+  #       uses: actions-cool/maintain-one-comment@v3.1.1
+  #       with:
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         body: |
+  #           Deploy PR Preview failed.
+  #           <!-- Sticky Pull Request Comment -->
+  #         body-include: '<!-- Sticky Pull Request Comment -->'
+  #         number: ${{ steps.pr.outputs.id }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -7,8 +7,11 @@ on:
       - completed
 
 inputs:
-  github_token:
+  github-token:
     description: 'Github token used to create PR comments'
+    required: true
+  ci-project:
+    description: 'Name of the CI project to track in LocalStack Cloud'
     required: true
 
 runs:
@@ -29,9 +32,9 @@ runs:
     - name: Update status comment
       uses: actions-cool/maintain-one-comment@v3.1.1
       with:
-        token: ${{ inputs.github_token }}
+        token: ${{ inputs.github-token }}
         body: |
-          🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci
+          🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/${{ inputs.ci-project }}
           <!-- Sticky Pull Request Comment -->
         body-include: '<!-- Sticky Pull Request Comment -->'
         number: ${{ steps.pr.outputs.pr_id }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -6,30 +6,35 @@ on:
     types:
       - completed
 
-jobs:
-  success:
-    runs-on: ubuntu-latest
+inputs:
+  github_token:
+    description: 'Github token used to create PR comments'
+    required: true
+
+runs:
+  using: composite
+  steps:
     # if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
-    steps:
-      - name: Download PR artifact
-        uses: dawidd6/action-download-artifact@v2
-        with:
-          workflow: ${{ github.event.workflow_run.workflow_id }}
-          name: pr
+    - name: Download PR artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        name: pr
 
-      - name: Load the PR ID
-        id: pr
-        run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
+    - name: Load the PR ID
+      id: pr
+      shell: bash
+      run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
 
-      - name: Update status comment
-        uses: actions-cool/maintain-one-comment@v3.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
-          number: ${{ steps.pr.outputs.pr_id }}
+    - name: Update status comment
+      uses: actions-cool/maintain-one-comment@v3.1.1
+      with:
+        token: ${{ inputs.github_token }}
+        body: |
+          🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci
+          <!-- Sticky Pull Request Comment -->
+        body-include: '<!-- Sticky Pull Request Comment -->'
+        number: ${{ steps.pr.outputs.pr_id }}
 
   # failed:
   #   runs-on: ubuntu-latest

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -1,0 +1,16 @@
+name: Start CI Build
+
+on: pull_request_target
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create initial PR comment
+        uses: actions-cool/maintain-one-comment@v3.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            ⚡️ Running CI build with LocalStack ...
+            <!-- Sticky Pull Request Comment -->
+          body-include: '<!-- Sticky Pull Request Comment -->'

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -1,9 +1,7 @@
 name: Start CI Build
 
-on: pull_request_target
-
 inputs:
-  github_token:
+  github-token:
     description: 'Github token used to create PR comments'
     required: true
   ci-project:
@@ -13,10 +11,20 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Save PR number
+      shell: bash
+      run: echo ${{ github.event.number }} > ./pr-id.txt
+
+    - name: Upload PR number
+      uses: actions/upload-artifact@v3
+      with:
+        name: pr
+        path: ./pr-id.txt
+
     - name: Create initial PR comment
       uses: actions-cool/maintain-one-comment@v3.1.1
       with:
-        token: ${{ inputs.github_token }}
+        token: ${{ inputs.github-token }}
         body: |
           ⚡️ Running CI build with LocalStack ...
           <!-- Sticky Pull Request Comment -->

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -6,6 +6,9 @@ inputs:
   github_token:
     description: 'Github token used to create PR comments'
     required: true
+  ci-project:
+    description: 'Name of the CI project to track in LocalStack Cloud'
+    required: false
 
 runs:
   using: composite

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -2,15 +2,19 @@ name: Start CI Build
 
 on: pull_request_target
 
-jobs:
-  prepare:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create initial PR comment
-        uses: actions-cool/maintain-one-comment@v3.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          body: |
-            ⚡️ Running CI build with LocalStack ...
-            <!-- Sticky Pull Request Comment -->
-          body-include: '<!-- Sticky Pull Request Comment -->'
+inputs:
+  github_token:
+    description: 'Github token used to create PR comments'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Create initial PR comment
+      uses: actions-cool/maintain-one-comment@v3.1.1
+      with:
+        token: ${{ inputs.github_token }}
+        body: |
+          ⚡️ Running CI build with LocalStack ...
+          <!-- Sticky Pull Request Comment -->
+        body-include: '<!-- Sticky Pull Request Comment -->'


### PR DESCRIPTION
This PR extends our Github action with additional configuration and logic to enable deeper integration with LocalStack Cloud Pods and CI projects. The logic of adding comments to the PR is inspired by the surge.sh preview configured in our docs repo: https://github.com/localstack/docs

An example can be found in this test repo here, where we created a test PR with a small change: https://github.com/whummer/localstack-pods-ci/pull/9

Once the PR is created, the following comment gets added to the PR:
<img width="924" alt="Screenshot 2023-09-23 at 21 31 03" src="https://github.com/localstack/setup-localstack/assets/2807888/1feb2dac-dde5-410d-8daa-91c1f654a7f0">

The build then runs, and once finished, the PR comment gets updated and contains a link to the CI run details in the LocalStack Web app (which then show the Cloud Pod and Stack Insights for this CI run):
<img width="918" alt="Screenshot 2023-09-23 at 22 08 16" src="https://github.com/localstack/setup-localstack/assets/2807888/192b2462-f072-414d-a598-2ddf5877618c">

Please note that the CI run feature is currently a beta feature and behind a feature flag (only used internally currently), hence the additional configurations `ci-project`/`github-token` are not yet exposed in the public documentation in this repo..

/cc @giograno @lukqw