### PR TITLE
Add initial action to create preview environments from PR builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,8 @@ runs:
   steps:
     - name: Initial PR comment
       # TODO: potentially replace with Action version number over time
-      uses: LocalStack/setup-localstack/prepare@main
+      # uses: LocalStack/setup-localstack/prepare@main
+      uses: LocalStack/setup-localstack/prepare@pr-preview
       if: inputs.ci-project && inputs.github-token
       with:
         github-token: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -76,6 +76,6 @@ runs:
         CONFIGURATION: "${{ inputs.configuration }}"
 
     # TODO: potentially add an additional step here to create preview envs, and add a switch to
-    #       to enable/disable the "Start LocalStack" action above. This way we could make this action
+    #       enable/disable the "Start LocalStack" action above. This way we could make this action
     #       the single entry point which then delegates to sub-actions in this repo, based on the
     #       user-provided configuration...

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Github token used to create PR comments'
     required: false
     default: ''
+  preview-cmd:
+    description: 'Command(s) used to create a preview of the PR (can use $AWS_ENDPOINT_URL)'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -70,3 +74,8 @@ runs:
         INSTALL_AWSLOCAL: "${{ inputs.install-awslocal }}"
         USE_PRO: "${{ inputs.use-pro }}"
         CONFIGURATION: "${{ inputs.configuration }}"
+
+    # TODO: potentially add an additional step here to create preview envs, and add a switch to
+    #       to enable/disable the "Start LocalStack" action above. This way we could make this action
+    #       the single entry point which then delegates to sub-actions in this repo, based on the
+    #       user-provided configuration...

--- a/action.yml
+++ b/action.yml
@@ -41,8 +41,7 @@ runs:
   steps:
     - name: Initial PR comment
       # TODO: potentially replace with Action version number over time
-      # uses: LocalStack/setup-localstack/prepare@main
-      uses: LocalStack/setup-localstack/prepare@pr-preview
+      uses: LocalStack/setup-localstack/prepare@main
       if: inputs.ci-project && inputs.github-token
       with:
         github-token: ${{ inputs.github-token }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -26,12 +26,15 @@ runs:
       shell: bash
       run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
 
+    # TODO: load preview URL from artifacts
+
     - name: Update status comment
       uses: actions-cool/maintain-one-comment@v3.1.1
       with:
         token: ${{ inputs.github-token }}
         body: |
-          🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/${{ inputs.ci-project }}
+          ${{ inputs.ci-project && `🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/${inputs.ci-project}` }}
+          ${{ inputs.include-preview && '🚀 Preview for this PR: TODO add link ...' }}
           <!-- Sticky Pull Request Comment -->
         body-include: '<!-- Sticky Pull Request Comment -->'
         number: ${{ steps.pr.outputs.pr_id }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -26,15 +26,22 @@ runs:
       shell: bash
       run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
 
-    # TODO: load preview URL from artifacts
+    - name: Load the preview URL
+      shell: bash
+      run: |
+        if [[ -e ls-preview-url.txt ]]; then
+          echo "LS_PREVIEW_URL=$(<ls-preview-url.txt)" >> $GITHUB_ENV
+        else
+          echo "LS_PREVIEW_URL=Unable to determine preview URL" >> $GITHUB_ENV
+        fi
 
     - name: Update status comment
       uses: actions-cool/maintain-one-comment@v3.1.1
       with:
         token: ${{ inputs.github-token }}
         body: |
-          ${{ inputs.ci-project && '🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/${{ inputs.ci-project }}' }}
-          ${{ inputs.include-preview && '🚀 Preview for this PR: TODO add link ...' }}
+          ${{ inputs.ci-project && format('{0}{1}', '🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/', inputs.ci-project) }}
+          ${{ inputs.include-preview && format('{0}{1}', '🚀 Preview for this PR: ', env.LS_PREVIEW_URL) }}
           <!-- Sticky Pull Request Comment -->
         body-include: '<!-- Sticky Pull Request Comment -->'
         number: ${{ steps.pr.outputs.pr_id }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -33,7 +33,7 @@ runs:
       with:
         token: ${{ inputs.github-token }}
         body: |
-          ${{ inputs.ci-project && `🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/${inputs.ci-project}` }}
+          ${{ inputs.ci-project && '🚀 LocalStack Stack Insights and Cloud Pod state for this CI run: https://app.localstack.cloud/ci/${{ inputs.ci-project }}' }}
           ${{ inputs.include-preview && '🚀 Preview for this PR: TODO add link ...' }}
           <!-- Sticky Pull Request Comment -->
         body-include: '<!-- Sticky Pull Request Comment -->'

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -5,8 +5,12 @@ inputs:
     description: 'Github token used to create PR comments'
     required: true
   ci-project:
-    description: 'Name of the CI project to track in LocalStack Cloud'
-    required: true
+    description: 'Name of the CI project tracked in LocalStack Cloud'
+    required: false
+  include-preview:
+    description: 'Whether to include the created preview URL in the PR comment'
+    type: boolean
+    default: false
 
 runs:
   using: composite

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -28,6 +28,7 @@ runs:
 
     - name: Load the preview URL
       shell: bash
+      if: inputs.include-preview
       run: |
         if [[ -e ls-preview-url.txt ]]; then
           echo "LS_PREVIEW_URL=$(<ls-preview-url.txt)" >> $GITHUB_ENV

--- a/preview/action.yml
+++ b/preview/action.yml
@@ -17,7 +17,8 @@ runs:
   steps:
     - name: Initial PR comment
       # TODO: potentially replace with Action version number over time
-      uses: LocalStack/setup-localstack/prepare@main
+      # uses: LocalStack/setup-localstack/prepare@main
+      uses: LocalStack/setup-localstack/prepare@pr-preview
       if: inputs.github-token
       with:
         github-token: ${{ inputs.github-token }}

--- a/preview/action.yml
+++ b/preview/action.yml
@@ -17,8 +17,7 @@ runs:
   steps:
     - name: Initial PR comment
       # TODO: potentially replace with Action version number over time
-      # uses: LocalStack/setup-localstack/prepare@main
-      uses: LocalStack/setup-localstack/prepare@pr-preview
+      uses: LocalStack/setup-localstack/prepare@main
       if: inputs.github-token
       with:
         github-token: ${{ inputs.github-token }}

--- a/preview/action.yml
+++ b/preview/action.yml
@@ -1,0 +1,57 @@
+name: Create PR Preview
+
+inputs:
+  github-token:
+    description: 'Github token used to create PR comments'
+    required: true
+  localstack-api-key:
+    description: 'LocalStack API key used to create the preview environment'
+    required: true
+  preview-cmd:
+    description: 'Command(s) used to create a preview of the PR (can use $AWS_ENDPOINT_URL)'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Initial PR comment
+      # TODO: potentially replace with Action version number over time
+      uses: LocalStack/setup-localstack/prepare@main
+      if: inputs.github-token
+      with:
+        github-token: ${{ inputs.github-token }}
+
+    - name: Download PR artifact
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ${{ github.event.workflow_run.workflow_id }}
+        name: pr
+
+    - name: Create preview environment
+      shell: bash
+      run: |
+        prId=$(<pr-id.txt)
+        # TODO: make preview name configurable!
+        previewName=preview-$prId
+
+        endpointUrl=$(curl -X POST -d '{}' \
+            -H 'authorization: token ${{ inputs.localstack-api-key }}' \
+            -H 'content-type: application/json' \
+            https://api.localstack.cloud/v1/previews/$previewName | jq -r .endpoint_url)
+        echo "Created preview environment with endpoint URL: $endpointUrl"
+
+        echo $endpointUrl > ./ls-preview-url.txt
+        echo "LS_PREVIEW_URL=$endpointUrl" >> $GITHUB_ENV
+        echo "AWS_ENDPOINT_URL=$endpointUrl" >> $GITHUB_ENV
+
+    - name: Upload preview instance URL
+      uses: actions/upload-artifact@v3
+      with:
+        name: ls-preview-url
+        path: ./ls-preview-url.txt
+
+    - name: Run preview deployment
+      shell: bash
+      run:
+        ${{ inputs.preview-cmd }}

--- a/preview/action.yml
+++ b/preview/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Upload preview instance URL
       uses: actions/upload-artifact@v3
       with:
-        name: ls-preview-url
+        name: pr
         path: ./ls-preview-url.txt
 
     - name: Run preview deployment

--- a/preview/action.yml
+++ b/preview/action.yml
@@ -24,9 +24,8 @@ runs:
         github-token: ${{ inputs.github-token }}
 
     - name: Download PR artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
-        workflow: ${{ github.event.workflow_run.workflow_id }}
         name: pr
 
     - name: Create preview environment
@@ -36,10 +35,15 @@ runs:
         # TODO: make preview name configurable!
         previewName=preview-$prId
 
-        endpointUrl=$(curl -X POST -d '{}' \
+        response=$(curl -X POST -d '{}' \
             -H 'authorization: token ${{ inputs.localstack-api-key }}' \
             -H 'content-type: application/json' \
-            https://api.localstack.cloud/v1/previews/$previewName | jq -r .endpoint_url)
+            https://api.localstack.cloud/v1/previews/$previewName)
+        endpointUrl=$(echo "$response" | jq -r .endpoint_url)
+        if [ "$endpointUrl" = "null" ] || [ "$endpointUrl" = "" ]; then
+          echo "Unable to create preview environment. API response: $response"
+          exit 1
+        fi
         echo "Created preview environment with endpoint URL: $endpointUrl"
 
         echo $endpointUrl > ./ls-preview-url.txt


### PR DESCRIPTION
Add initial Action to create preview environments from PR builds. Note that these features are in internal/beta state at this stage, hence are not exposed in the public docs of this Action.

The PR adds a new `preview/action.yml` file with an input parameter `preview-cmd`, which can be used to define the build steps for the preview environment, using the value in `AWS_ENDPOINT_URL` as the target endpoint to deploy against.

Demo repo here: https://github.com/whummer/bref-localstack-sample/pull/3
See here for the deployment steps in the demo app: https://github.com/whummer/bref-localstack-sample/blob/main/.github/workflows/ci-preview.yml#L21-L33

Side note: Based on these changes, we can further iterate on the functionality, and further streamline this Action in the future. 👍 For example, the `Start LocalStack` build step is still the main step, but may not be required in all cases. See also the `TODO` comment in the main `action.yml` file in the repo 

/cc @lukqw @HarshCasper 