### PR TITLE
add correct headers for preview api call

### DIFF
--- a/preview/action.yml
+++ b/preview/action.yml
@@ -35,6 +35,7 @@ runs:
         previewName=preview-$prId
 
         response=$(curl -X POST -d '{}' \
+            -H 'ls-api-key: ${{ inputs.localstack-api-key }}' \
             -H 'authorization: token ${{ inputs.localstack-api-key }}' \
             -H 'content-type: application/json' \
             https://api.localstack.cloud/v1/previews/$previewName)


### PR DESCRIPTION
Seems like our backend implementation has changed for authorization, so I'm adjusting the action to properly pass the api key.

We should probably clean this up properly later on.