### PR TITLE
ci: Add weekly smoke test and manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: LocalStack Test
-on: [ push, pull_request ]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '48 23 * * 0'
 
 jobs:
   localstack-action-test:


### PR DESCRIPTION
# Motivation

The repo is not getting frequent updates so if the Action would fail we're not aware of it.

# Changes
- add weekly scheduled smoke test run
- add option to manually trigger the pipeline