### PR TITLE
update docs to use latest version, not a future version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started, you can use this minimal example:
 
 ```yml
 - name: Start LocalStack
-  uses: LocalStack/setup-localstack@v0.1.3
+  uses: LocalStack/setup-localstack@v0.1.2
   with:
     image-tag: 'latest'
     install-awslocal: 'true'
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.1.3
+        uses: LocalStack/setup-localstack@v0.1.2
         with:
           image-tag: 'latest'
           install-awslocal: 'true'


### PR DESCRIPTION
It looks like the README specifies version 0.1.3 for the action. Per the [marketplace](https://github.com/marketplace/actions/setup-localstack) website, the latest version is 0.1.2. This PR updates the readme to use the latest version instead of a future one.