### PR TITLE
Add shutdown ephemeral instance action + test

### DIFF
--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -19,3 +19,4 @@ jobs:
         uses: ./ephemeral/shutdown
         with:
           localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -16,7 +16,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Finalize PR comment
-        uses: LocalStack/setup-localstack/finish@main
+        uses: ./finish
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           include-preview: true

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -14,6 +14,11 @@ jobs:
           localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Finalize PR comment
+        uses: LocalStack/setup-localstack/finish@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          include-preview: true
           
       - name: Shutdown ephemeral instance
         uses: ./ephemeral/shutdown

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -3,6 +3,7 @@ on:  pull_request
 
 jobs:
   preview-test:
+    permissions: write-all
     name: 'Test ephemeral instance workflow'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -1,0 +1,19 @@
+name: LocalStack Ephemeral Instance Test
+on:  pull_request
+
+jobs:
+  preview-test:
+    name: 'Test ephemeral instance workflow'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Deploy Preview
+        uses: ./preview
+        with:
+          localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}
+          
+      - name: Shutdown ephemeral instance
+        uses: ./ephemeral/shutdown
+        with:
+          localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -12,6 +12,8 @@ jobs:
         uses: ./preview
         with:
           localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
           
       - name: Shutdown ephemeral instance
         uses: ./ephemeral/shutdown

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -14,12 +14,6 @@ jobs:
         with:
           localstack-api-key: ${{ secrets.LOCALSTACK_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Finalize PR comment
-        uses: ./finish
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          include-preview: true
           
       - name: Shutdown ephemeral instance
         uses: ./ephemeral/shutdown

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -17,6 +17,11 @@ runs:
       with:
         name: pr
 
+    - name: Load the PR ID
+      id: pr
+      shell: bash
+      run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
+
     - name: Shutdown ephemeral instance
       shell: bash
       run: |
@@ -40,7 +45,7 @@ runs:
       with:
         token: ${{ inputs.github-token }}
         body: |
-          The ephemeral instance for the application preview has been shutdown
+          The ephemeral instance for the application preview has been shut down
           <!-- Sticky Pull Request Comment -->
         body-include: '<!-- Sticky Pull Request Comment -->'
         number: ${{ steps.pr.outputs.pr_id }}

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -1,0 +1,31 @@
+name: Shutdown Ephemeral Instance
+
+inputs:
+  localstack-api-key:
+    description: 'LocalStack API key used to access the platform api'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download PR artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: pr
+
+    - name: Shutdown ephemeral instance
+      shell: bash
+      run: |
+        prId=$(<pr-id.txt)
+        # TODO: make preview_name configurable
+        previewName=preview-$prId
+
+        response=$(curl -X DELETE \
+            -H 'ls-api-key: ${{ inputs.localstack-api-key }}' \
+            -H 'authorization: token ${{ inputs.localstack-api-key }}' \
+            -H 'content-type: application/json' \
+            https://api.localstack.cloud/v1/previews/$previewName)
+        if [[ "$response" != "{}" ]]; then
+          echo "Unable to delete preview environment. API response: $response"
+          exit 1
+        fi

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -40,7 +40,7 @@ runs:
       with:
         token: ${{ inputs.github-token }}
         body: |
-          The Ephemeral Instance has been shutdown
+          The ephemeral instance for the application preview has been shutdown
           <!-- Sticky Pull Request Comment -->
         body-include: '<!-- Sticky Pull Request Comment -->'
         number: ${{ steps.pr.outputs.pr_id }}

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -26,6 +26,7 @@ runs:
             -H 'content-type: application/json' \
             https://api.localstack.cloud/v1/previews/$previewName)
         if [[ "$response" != "{}" ]]; then
+          # In case the deletion fails, e.g. if the instance cannot be found, we raise a proper error on the platform
           echo "Unable to delete preview environment. API response: $response"
           exit 1
         fi

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -4,6 +4,10 @@ inputs:
   localstack-api-key:
     description: 'LocalStack API key used to access the platform api'
     required: true
+  github-token:
+    description: 'Github token used to create PR comments'
+    required: true
+    
 
 runs:
   using: composite
@@ -30,3 +34,13 @@ runs:
           echo "Unable to delete preview environment. API response: $response"
           exit 1
         fi
+    
+    - name: Update status comment
+      uses: actions-cool/maintain-one-comment@v3.1.1
+      with:
+        token: ${{ inputs.github-token }}
+        body: |
+          The Ephemeral Instance has been shutdown
+          <!-- Sticky Pull Request Comment -->
+        body-include: '<!-- Sticky Pull Request Comment -->'
+        number: ${{ steps.pr.outputs.pr_id }}


### PR DESCRIPTION
## Context
This PR adds a new action to shutdown ephemeral instance to our suite of actions.
It further adds a small test suite that checks the flow of starting / stopping an ephemeral instance.

## Honorable mentions
This PR copies parts of #12 for which I want to give kudos to @Pive01!


## Future work
I plan to move the `preview` action to the `ephemeral` directory and rename it to `start`.
Further I'd like to get rid of the data exchange based on artifacts, and switch to either proper inputs/outputs or env var based data passing.