### PR TITLE
Improve local cache hack

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,10 +72,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: echo "$(ls -d ./../../_actions/LocalStack/setup-localstack/* | grep -v completed)"
-      shell: bash
-
-    - run: echo "GH_ACTION_ROOT=$(ls -d ./../../_actions/LocalStack/setup-localstack/* | grep -v completed)" >> $GITHUB_ENV
+    - run: >
+        echo "GH_ACTION_ROOT=$(
+          ls -d $(
+            ls -d ./../../_actions/* |
+            grep -i localstack |
+            tail -n1
+          )/setup-localstack/* | 
+          grep -v completed | 
+          tail -n1
+        )" >> $GITHUB_ENV
       shell: bash
     
     - name: Install tools

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -19,7 +19,16 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: echo "GH_ACTION_ROOT=$(ls -d ./../../_actions/LocalStack/setup-localstack/* | grep -v completed)" >> $GITHUB_ENV
+    - run: >
+        echo "GH_ACTION_ROOT=$(
+          ls -d $(
+            ls -d ./../../_actions/* |
+            grep -i localstack |
+            tail -n1
+          )/setup-localstack/* | 
+          grep -v completed | 
+          tail -n1
+        )" >> $GITHUB_ENV
       shell: bash
 
     - name: Initial PR comment

--- a/startup/action.yml
+++ b/startup/action.yml
@@ -37,7 +37,16 @@ runs:
     #   with:
     #     github-token: ${{ inputs.github-token }}
     #     ci-project: ${{ inputs.ci-project }}
-    - run: echo "GH_ACTION_ROOT=$(ls -d ./../../_actions/LocalStack/setup-localstack/* | grep -v completed)" >> $GITHUB_ENV
+    - run: >
+        echo "GH_ACTION_ROOT=$(
+          ls -d $(
+            ls -d ./../../_actions/* |
+            grep -i localstack |
+            tail -n1
+          )/setup-localstack/* | 
+          grep -v completed | 
+          tail -n1
+        )" >> $GITHUB_ENV
       shell: bash
 
     - name: Install tools


### PR DESCRIPTION
# Motivation
Our GHA can be referenced multiple ways, ie with `LocalStack/setup-localstack` or as `localstack/setup-localstack`. However our local cache hack is not tolerating the variations and it fails if other versions are present. To fix this we'd like to ignore case sensitivity and pick the last available version in the cache.
The precedence order will be alphabetic due to ls.
Hence the resulted precedence order will be:
- localstack < LocalStack
- v0.1.2 < v0.2.0
- main < v0.1.2

# Changes
- ignore cases
- enforce the above precedence order