### PR TITLE
Fix image-tag input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           echo "Test Execution complete!"
 
   localstack-action-version-test:
-    name: 'Test LocalStack GitHub Action'
+    name: 'Test LocalStack Version with Github Actions'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -65,9 +65,10 @@ jobs:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
           GH_ACTION_VERSION: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
 
-      - name: Run Tests Against LocalStack
+      - name: Run Version Test Against LocalStack
         run: |
-          exit $(test "x$(docker ps | grep localstack | cut -d " " -f4 | cut -d ":" -f2)" = "x3.2.0")
+          LS_VERSION=$(docker ps | grep localstack | cut -d " " -f4 | cut -d ":" -f2)
+          exit $(test "x${LS_VERSION}" = "x3.2.0")
 
   cloud-pods-test:
     name: 'Test Cloud Pods Action'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,33 @@ jobs:
           awslocal s3 ls
           echo "Test Execution complete!"
 
+  localstack-action-version-test:
+    name: 'Test LocalStack GitHub Action'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # We must hack the action call as remote to be able to use the relative paths
+      # Could it break with different CWD? 🤔
+      - name: Start LocalStack
+        uses: jenseng/dynamic-uses@v1
+        with:
+          uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
+          with: |-
+            {
+              "image-tag": "3.2.0",
+              "install-awslocal": "true",
+              "configuration": "DEBUG=1",
+              "use-pro": "true",
+            }
+        env:
+          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          GH_ACTION_VERSION: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+
+      - name: Run Tests Against LocalStack
+        run: |
+          exit $(test "x$(docker ps | grep localstack | cut -d " " -f4 | cut -d ":" -f2)" = "x3.2.0")
+
   cloud-pods-test:
     name: 'Test Cloud Pods Action'
     runs-on: ubuntu-latest

--- a/startup/action.yml
+++ b/startup/action.yml
@@ -55,12 +55,14 @@ runs:
           if [ "x$LOCALSTACK_AUTH_TOKEN" = "x" -o "x$LOCALSTACK_API_KEY" = "x" ]; then
             echo "WARNING: LocalStack API key not detected, please verify your configuration..."
           fi
-          docker pull localstack/localstack-pro:"$IMAGE_TAG" &
-          CONFIGURATION="$CONFIGURATION DNS_ADDRESS=127.0.0.1"
+          CONFIGURATION="DNS_ADDRESS=127.0.0.1 ${CONFIGURATION}"
+          IMAGE_NAME="${IMAGE_NAME:-localstack/localstack-pro:${IMAGE_TAG}}"
         else
-          docker pull localstack/localstack:"$IMAGE_TAG" &
+          IMAGE_NAME="${IMAGE_NAME:-localstack/localstack:${IMAGE_TAG}}"
         fi
 
+        CONFIGURATION="IMAGE_NAME=${IMAGE_NAME} ${CONFIGURATION}"
+        docker pull ${IMAGE_NAME} &
         export CI_PROJECT=${{ inputs.ci-project }}
         eval "${CONFIGURATION} localstack start -d"
 

--- a/tools/action.yml
+++ b/tools/action.yml
@@ -11,6 +11,7 @@ runs:
   steps:
     - name: Start LocalStack
       run: |
+        pip install --upgrade pip
         which localstack > /dev/null || pip install localstack
         if [ "$INSTALL_AWSLOCAL" = true ]; then
           which awslocal > /dev/null || pip install awscli-local[ver1]


### PR DESCRIPTION
# Motivation
Image tag causing currently more confusion than what it solves, namely: 
- cli fails back to 3.2.0 if default pip version used
- correct image version downloaded but LS not starting that

# Changes
- pip upgrade
- new version test pipeline
- image_name env var used to control image version
- image-tag parameter populates image_name if the env variable missing