### PR TITLE
Fix preview URL precedence

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -133,8 +133,6 @@ runs:
     - name: Display Ephemeral Instance URL
       if: ${{ inputs.state-action == 'start' && inputs.state-backend == 'ephemeral' && (inputs.include-preview == 'true' || inputs.ci-project != '') }}
       uses: jenseng/dynamic-uses@v1
-      env:
-        default-include-preview: ${{ fromJSON('["false","true"]')[github.event_name == 'pull_request'] }}
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/finish
         with: |-

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
 
     - run: echo "GH_ACTION_ROOT=$(ls -d ./../../_actions/LocalStack/setup-localstack/* | grep -v completed)" >> $GITHUB_ENV
       shell: bash
-    
+
     - name: Install tools
       uses: jenseng/dynamic-uses@v1
       if: ${{ inputs.skip-startup == 'true' || inputs.state-backend == 'ephemeral' || inputs.state-action == 'save' }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -32,8 +32,8 @@ runs:
       shell: bash
       if: inputs.include-preview
       run: |
-        if [[ -n "${{ inputs.preview-url }}" ]]; then
-          echo "LS_PREVIEW_URL=${{ inputs.preview-url }}" >> $GITHUB_ENV
+        if [[ -n "${LS_PREVIEW_URL:-${{ inputs.preview-url }}}" ]]; then
+          echo "LS_PREVIEW_URL=${LS_PREVIEW_URL:-${{ inputs.preview-url }}}" >> $GITHUB_ENV
         elif [[ -e ls-preview-url.txt ]]; then
           echo "LS_PREVIEW_URL=$(<ls-preview-url.txt)" >> $GITHUB_ENV
         else

--- a/tools/action.yml
+++ b/tools/action.yml
@@ -11,11 +11,11 @@ runs:
   steps:
     - name: Start LocalStack
       run: |
+        pip install --upgrade pip
         which localstack > /dev/null || pip install localstack
         if [ "$INSTALL_AWSLOCAL" = true ]; then
           which awslocal > /dev/null || pip install awscli-local[ver1]
         fi
-
       shell: bash
       env:
         INSTALL_AWSLOCAL: "${{ inputs.install-awslocal }}"


### PR DESCRIPTION
# Motivation
The precedence order in the finish action is off as the user unable to overdefine any point the preview-url.
Ideally we'd like to use the following top to bottom (higher takes precedence) approach:
- env variable
- action parameter
- (artifact) file

# Changes
- change precedence order