### PR TITLE
Fix download actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,9 @@ jobs:
               "install-awslocal": "true",
               "configuration": "DEBUG=1",
               "use-pro": "true",
+              "state-name": "cloud-pods-test",
+              "state-action": "load",
+              "state-backend": "local",
             }
         env:
           LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
@@ -134,7 +137,9 @@ jobs:
 
       - name: Run AWS Commands
         run: |
+          awslocal s3 rb s3://test
           awslocal s3 mb s3://test
+          awslocal sqs delete-queue --queue-url $(awslocal sqs get-queue-url --queue-name test-queue --output text)
           awslocal sqs create-queue --queue-name test-queue
 
       - name: Save the State Artifact

--- a/action.yml
+++ b/action.yml
@@ -151,7 +151,7 @@ runs:
           }
     
     - name: Stop Ephemeral Instance
-      if: ${{ !inputs.skip-ephemeral-stop && inputs.state-action == 'stop' && inputs.state-backend == 'ephemeral' }}
+      if: ${{ inputs.skip-ephemeral-stop == 'false' && inputs.state-action == 'stop' && inputs.state-backend == 'ephemeral' }}
       uses: jenseng/dynamic-uses@v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/ephemeral/shutdown

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ inputs:
   skip-ephemeral-stop:
     description: 'Skip stopping LocalStack Ephemeral Instance'
     required: false
-    default: 'false'
+    default: 'true'
   state-action:
     description: |
       Manage LocalStack state
@@ -151,7 +151,7 @@ runs:
           }
     
     - name: Stop Ephemeral Instance
-      if: ${{ inputs.skip-ephemeral-stop == 'false' && inputs.state-action == 'stop' && inputs.state-backend == 'ephemeral' }}
+      if: ${{ (inputs.skip-ephemeral-stop == 'false' || inputs.state-action == 'stop') && inputs.state-backend == 'ephemeral' }}
       uses: jenseng/dynamic-uses@v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/ephemeral/shutdown

--- a/action.yml
+++ b/action.yml
@@ -157,5 +157,5 @@ runs:
         uses: ${{ env.GH_ACTION_ROOT }}/ephemeral/shutdown
         with: |-
           {
-            "name": ${{ toJSON(inputs.github-token) }},
+            "github-token": ${{ toJSON(inputs.github-token) }},
           }

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -17,10 +17,23 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download PR artifact
+    # Try to get pr artifact from current workflow
+    - name: Download current PR artifact
+      id: get-pr-artifact
       uses: actions/download-artifact@v3
+      continue-on-error: true
       with:
         name: pr
+
+    # If the above fails, try to get the latest pr artifact from the PR related workflows
+    - name: Download latest PR artifact
+      uses: dawidd6/action-download-artifact@v6
+      if: ${{ steps.get-pr-artifact.conclusion == 'failure' }}
+      with:
+        name: pr
+        pr: ${{ github.event.pull_request.number }}
+        # Can be ID or workflow file name, if empty falls back to the latest successful run of the current workflow
+        workflow: §{{ env.PR_ARTIFACT_WORKFLOW }}
 
     - name: Load the PR ID
       id: pr

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -18,10 +18,8 @@ runs:
   using: composite
   steps:
     - name: Download PR artifact
-      uses: dawidd6/action-download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
-        workflow: ${{ env.WORKFLOW_ID == '' && github.event.workflow_run.workflow_id || env.WORKFLOW_ID }}
-        workflow_conclusion: ${{ env.WORKFLOW_CONCLUSION }}
         name: pr
 
     - name: Load the PR ID

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -28,7 +28,7 @@ runs:
     # If the above fails, try to get the latest pr artifact from the PR related workflows
     - name: Download latest PR artifact
       uses: dawidd6/action-download-artifact@v6
-      if: ${{ steps.get-pr-artifact.conclusion == 'failure' }}
+      if: ${{ steps.get-pr-artifact.outcome == 'failure' }}
       with:
         name: pr
         pr: ${{ github.event.pull_request.number }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -33,7 +33,7 @@ runs:
         name: pr
         pr: ${{ github.event.pull_request.number }}
         # Can be ID or workflow file name, if empty falls back to the latest successful run of the current workflow
-        workflow: §{{ env.PR_ARTIFACT_WORKFLOW }}
+        workflow: ${{ env.PR_ARTIFACT_WORKFLOW }}
 
     - name: Load the PR ID
       id: pr

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -20,7 +20,8 @@ runs:
     - name: Download PR artifact
       uses: dawidd6/action-download-artifact@v2
       with:
-        workflow: ${{ github.event.workflow_run.workflow_id }}
+        workflow: ${{ env.WORKFLOW_ID == '' && github.event.workflow_run.workflow_id || env.WORKFLOW_ID }}
+        workflow_conclusion: ${{ env.WORKFLOW_CONCLUSION }}
         name: pr
 
     - name: Load the PR ID

--- a/local/action.yml
+++ b/local/action.yml
@@ -13,12 +13,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download PR artifact
-      uses: dawidd6/action-download-artifact@v2
+    # Try to get pr artifact from current workflow
+    - name: Download current workflow's Local State artifact
+      id: get-state-artifact
       if: ${{ inputs.action == 'load' }}
+      uses: actions/download-artifact@v3
+      continue-on-error: true
       with:
-        workflow: ${{ env.WORKFLOW_ID == '' && github.event.workflow_run.workflow_id || env.WORKFLOW_ID }}
         name: ${{ inputs.name }}
+
+    # If the above fails, try to get the latest artifact from given workflow
+    - name: Download latest Local State artifact
+      uses: dawidd6/action-download-artifact@v6
+      if: ${{ inputs.action == 'load' && steps.get-state-artifact.outcome == 'failure' }}
+      with:
+        name: ${{ inputs.name }}
+        workflow: ${{ env.LS_STATE_ARTIFACT_WORKFLOW }} # Can be ID or workflow file name, if empty falls back to the latest successful run of the current workflow
+        if_no_artifact_found: warn
 
     - run: |
         if [ "$ACTION" = "save" ]; then

--- a/local/action.yml
+++ b/local/action.yml
@@ -16,10 +16,8 @@ runs:
     - name: Download PR artifact
       uses: dawidd6/action-download-artifact@v2
       if: ${{ inputs.action == 'load' }}
-      env:
-        workflow_id: ${{ env.WORKFLOW_ID == '' && github.event.workflow_run.workflow_id || env.WORKFLOW_ID }} 
       with:
-        workflow: 
+        workflow: ${{ env.WORKFLOW_ID == '' && github.event.workflow_run.workflow_id || env.WORKFLOW_ID }}
         name: ${{ inputs.name }}
 
     - run: |


### PR DESCRIPTION
# Motivation
Finish comment sometimes not updated by the new action, instead it's picking up the previous PR comment.
It seems the source of the issue is the download action `dawidd6/action-download-artifact@v2` which only picks up successfully concluded workflows by default. As a result the currently running pipeline is not among these instead it's picking the latest successful run on the workflow which can be a different PR.
By adding 2 download actions we try to download the artifact first from the current pipeline, if that's not successful we try to download an artifact from the latest successful PR pipeline, if this fails we fail.
Additionally we provide an env variable to override the workflow we're looking for the artifact, however this must be part of the PR.

# Changes
- add action/artifact-download to handle current pipeline artifacts
- add v6 version of the old action to be able to search PRs properly
- allow overriding with env variables for workflow `PR_ARTIFACT_WORKFLOW`
- small fix on shutdown action's comment
- apply this download method on local state management