### PR TITLE
Improve application previews by preventing naming collision

### DIFF
--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         prId=$(<pr-id.txt)
         repoName=$GITHUB_REPOSITORY
-        repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]\n' '-')
+        repoNameCleaned=$(echo -n "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
         echo "previewName=$previewName" >> $GITHUB_ENV
 

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -22,18 +22,24 @@ runs:
       shell: bash
       run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
 
-    - name: Shutdown ephemeral instance
+    - name: Setup preview name
       shell: bash
       run: |
         prId=$(<pr-id.txt)
-        # TODO: make preview_name configurable
-        previewName=preview-$prId
+        repoName=$GITHUB_REPOSITORY
+        repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]\n' '-')
+        previewName=preview-$repoNameCleaned-$prId
+        echo "previewName=$previewName" >> $GITHUB_ENV
 
+    - name: Shutdown ephemeral instance
+      shell: bash
+      run: |
         response=$(curl -X DELETE \
+            -s -o /dev/null -w "%{http_code}" \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \
             -H "content-type: application/json" \
             https://api.localstack.cloud/v1/compute/instances/$previewName)
-        if [[ "$response" != "{}" ]]; then
+        if [[ "$response" -ne 200 ]]; then
           # In case the deletion fails, e.g. if the instance cannot be found, we raise a proper error on the platform
           echo "Unable to delete preview environment. API response: $response"
           exit 1

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -82,7 +82,13 @@ runs:
 
         instance_exists=$(echo "$list_response" | jq --arg NAME "$previewName" '.[] | select(.name == $NAME)')
 
-        echo $instance_exists
+
+        if [ -n "$instance_exists" ]; then
+          echo "Match found: $MATCH"
+        else
+          echo "No match found."
+        fi
+
 
         if [ -n "$instance_exists" ]; then
           del_response=$(curl -X DELETE \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -55,16 +55,39 @@ runs:
       with:
         name: pr
 
-    - name: Create preview environment
+    - name: Setup preview name
       shell: bash
       run: |
         prId=$(<pr-id.txt)
-        # TODO: make preview name configurable!
-        previewName=preview-$prId
+        repoName=$GITHUB_REPOSITORY
+        repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
+        previewName=preview-$repoNameCleaned-$prId
 
+    - name: Create preview environment
+      shell: bash
+      run: |
         autoLoadPod="${AUTO_LOAD_POD:-${{ inputs.auto-load-pod }}}"
         extensionAutoInstall="${EXTENSION_AUTO_INSTALL:-${{ inputs.extension-auto-install }}}"
         lifetime="${{ inputs.lifetime }}"
+
+        list_response=$(curl -X GET \
+            -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \
+            -H "content-type: application/json" \
+            https://api.localstack.cloud/v1/compute/instances)
+
+        echo $list_response
+
+        instance_exists=$(echo "$list_response" | jq --arg NAME "$previewName" '.[] | select(.name == $NAME)')
+
+        echo $instance_exists
+
+        if [ -n "$instance_exists" ]; then
+          del_response=$(curl -X DELETE \
+            -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \
+            -H "content-type: application/json" \
+            https://api.localstack.cloud/v1/compute/instances/$previewName)
+            echo $del_response
+        fi
 
         response=$(curl -X POST -d "{\"instance_name\": \"${previewName}\", \"lifetime\": ${lifetime} ,\"env_vars\": {\"AUTO_LOAD_POD\": \"${autoLoadPod}\", \"EXTENSION_AUTO_INSTALL\": \"${extensionAutoInstall}\"}}"\
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -59,7 +59,7 @@ runs:
       shell: bash
       run: |
         prId=$(<pr-id.txt)
-        repoName=$(echo "$GITHUB_REPOSITORY" | xargs)
+        repoName=$(echo "$GITHUB_REPOSITORY" | sed 's/^[ \t]*//;s/[ \t]*$//')
         echo $repoName
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -78,24 +78,13 @@ runs:
             -H "content-type: application/json" \
             https://api.localstack.cloud/v1/compute/instances)
 
-        echo $list_response
-
         instance_exists=$(echo "$list_response" | jq --arg NAME "$previewName" '.[] | select(.instance_name == $NAME)')
-
-
-        if [ -n "$instance_exists" ]; then
-          echo "Match found: $MATCH"
-        else
-          echo "No match found."
-        fi
-
 
         if [ -n "$instance_exists" ]; then
           del_response=$(curl -X DELETE \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \
             -H "content-type: application/json" \
             https://api.localstack.cloud/v1/compute/instances/$previewName)
-            echo $del_response
         fi
 
         response=$(curl -X POST -d "{\"instance_name\": \"${previewName}\", \"lifetime\": ${lifetime} ,\"env_vars\": {\"AUTO_LOAD_POD\": \"${autoLoadPod}\", \"EXTENSION_AUTO_INSTALL\": \"${extensionAutoInstall}\"}}"\

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -59,7 +59,7 @@ runs:
       shell: bash
       run: |
         prId=$(<pr-id.txt)
-        repoName=$($GITHUB_REPOSITORY | xargs)
+        repoName=$(echo "$GITHUB_REPOSITORY" | xargs)
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
         echo "previewName=$previewName" >> $GITHUB_ENV

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -80,7 +80,7 @@ runs:
 
         echo $list_response
 
-        instance_exists=$(echo "$list_response" | jq --arg NAME "$previewName" '.[] | select(.name == $NAME)')
+        instance_exists=$(echo "$list_response" | jq --arg NAME "$previewName" '.[] | select(.instance_name == $NAME)')
 
 
         if [ -n "$instance_exists" ]; then

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -62,6 +62,7 @@ runs:
         repoName=$GITHUB_REPOSITORY
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
+        echo $previewName
 
     - name: Create preview environment
       shell: bash

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -59,7 +59,7 @@ runs:
       shell: bash
       run: |
         prId=$(<pr-id.txt)
-        repoName=$GITHUB_REPOSITORY | xargs
+        repoName=$($GITHUB_REPOSITORY | xargs)
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
         echo "previewName=$previewName" >> $GITHUB_ENV

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -60,7 +60,7 @@ runs:
       run: |
         prId=$(<pr-id.txt)
         repoName=$GITHUB_REPOSITORY
-        repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]\n' '-')
+        repoNameCleaned=$(echo -n "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
         echo "previewName=$previewName" >> $GITHUB_ENV
 

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -60,6 +60,7 @@ runs:
       run: |
         prId=$(<pr-id.txt)
         repoName=$(echo "$GITHUB_REPOSITORY" | xargs)
+        echo $repoName
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
         echo "previewName=$previewName" >> $GITHUB_ENV

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -59,14 +59,10 @@ runs:
       shell: bash
       run: |
         prId=$(<pr-id.txt)
-        repoName=$GITHUB_REPOSITORY
+        repoName=$GITHUB_REPOSITORY | xargs
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
-        echo $GITHUB_REPOSITORY
-        echo $previewName
-        echo "test"
         echo "previewName=$previewName" >> $GITHUB_ENV
-
 
     - name: Create preview environment
       shell: bash

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -59,10 +59,9 @@ runs:
       shell: bash
       run: |
         prId=$(<pr-id.txt)
-        repoName=$(echo "$GITHUB_REPOSITORY" | sed 's/^[ \t]*//;s/[ \t]*$//')
-        echo $repoName
+        repoName=$GITHUB_REPOSITORY
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
-        previewName=preview-$repoNameCleaned-$prId
+        previewName=preview-$repoNameCleaned$prId
         echo "previewName=$previewName" >> $GITHUB_ENV
 
     - name: Create preview environment

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -70,6 +70,8 @@ runs:
         extensionAutoInstall="${EXTENSION_AUTO_INSTALL:-${{ inputs.extension-auto-install }}}"
         lifetime="${{ inputs.lifetime }}"
 
+        echo $previewName
+
         list_response=$(curl -X GET \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \
             -H "content-type: application/json" \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -60,8 +60,8 @@ runs:
       run: |
         prId=$(<pr-id.txt)
         repoName=$GITHUB_REPOSITORY
-        repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
-        previewName=preview-$repoNameCleaned$prId
+        repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]\n' '-')
+        previewName=preview-$repoNameCleaned-$prId
         echo "previewName=$previewName" >> $GITHUB_ENV
 
     - name: Create preview environment

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -63,6 +63,7 @@ runs:
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
         echo $previewName
+        echo "test"
 
     - name: Create preview environment
       shell: bash

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -62,8 +62,11 @@ runs:
         repoName=$GITHUB_REPOSITORY
         repoNameCleaned=$(echo "$repoName" | tr -c '[:alnum:]' '-')
         previewName=preview-$repoNameCleaned-$prId
+        echo $GITHUB_REPOSITORY
         echo $previewName
         echo "test"
+        echo "previewName=$previewName" >> $GITHUB_ENV
+
 
     - name: Create preview environment
       shell: bash

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -71,8 +71,6 @@ runs:
         extensionAutoInstall="${EXTENSION_AUTO_INSTALL:-${{ inputs.extension-auto-install }}}"
         lifetime="${{ inputs.lifetime }}"
 
-        echo $previewName
-
         list_response=$(curl -X GET \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \
             -H "content-type: application/json" \


### PR DESCRIPTION
## Background
While working on the blog post around ephemeral instances, @remotesynth and @HarshCasper both ran into the same issue: 
Pushing two commits in close succession would first yield a successful application preview deployment, while the second commit would run into an error with an `already_exists` message. 
This is because the name of the instance was already taken by the first commit and related preview deployment.

## Solution
This PR changes the naive approach that was previously used:
Instead of simply calling our creation endpoint, we first detect whether an instance with the same name is already running, and shut it down in case that's true, before starting the instance.
