### PR TITLE
print logs of ephemeral instance after executing preview-cmd

### DIFF
--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -29,6 +29,7 @@ jobs:
           PREVIEW_CMD: |-
             awslocal s3 mb s3://test-bucket
             awslocal sqs create-queue --queue-name=test-queue
+            exit 1
             echo "Deploy is done."
         
       - name: Assertion step

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -29,7 +29,6 @@ jobs:
           PREVIEW_CMD: |-
             awslocal s3 mb s3://test-bucket
             awslocal sqs create-queue --queue-name=test-queue
-            exit 1
             echo "Deploy is done."
         
       - name: Assertion step

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -114,8 +114,8 @@ runs:
         ${{ inputs.preview-cmd }}
 
     - name: Print logs of ephemeral instance
-      shell: bash
       if: steps.preview-cmd.outcome == 'failure' || steps.preview-cmd.outcome == 'success'
+      shell: bash
       run: |
         log_response=$(curl -X GET \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -109,11 +109,13 @@ runs:
     - name: Run preview deployment
       if: ${{ inputs.preview-cmd != '' }}
       shell: bash
+      id: preview-cmd
       run:
         ${{ inputs.preview-cmd }}
 
     - name: Print logs of ephemeral instance
       shell: bash
+      if: steps.preview-cmd.outcome == 'failure' || steps.preview-cmd.outcome == 'success'
       run: |
         log_response=$(curl -X GET \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -108,13 +108,12 @@ runs:
 
     - name: Run preview deployment
       if: ${{ inputs.preview-cmd != '' }}
-      id: preview-cmd
       shell: bash
       run:
         ${{ inputs.preview-cmd }}
 
     - name: Print logs of ephemeral instance
-      if: steps.preview-cmd.outcome == 'failure' || steps.preview-cmd.outcome == 'success'
+      if: always()
       shell: bash
       run: |
         log_response=$(curl -X GET \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -108,14 +108,14 @@ runs:
 
     - name: Run preview deployment
       if: ${{ inputs.preview-cmd != '' }}
-      shell: bash
       id: preview-cmd
+      shell: bash
       run:
         ${{ inputs.preview-cmd }}
 
     - name: Print logs of ephemeral instance
       shell: bash
-      if: always()
+      if: steps.preview-cmd.outcome == 'failure' || steps.preview-cmd.outcome == 'success'
       run: |
         log_response=$(curl -X GET \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -120,4 +120,4 @@ runs:
             -H "content-type: application/json" \
             https://api.localstack.cloud/v1/compute/instances/$previewName/logs)
         
-        echo $log_response
+        echo "$log_response" | jq -r '.[].content'

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -111,3 +111,13 @@ runs:
       shell: bash
       run:
         ${{ inputs.preview-cmd }}
+
+    - name: Print logs of ephemeral instance
+      shell: bash
+      run: |
+        log_response=$(curl -X GET \
+            -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \
+            -H "content-type: application/json" \
+            https://api.localstack.cloud/v1/compute/instances/$previewName/logs)
+        
+        echo $log_response

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Print logs of ephemeral instance
       shell: bash
-      if: steps.preview-cmd.outcome == 'failure' || steps.preview-cmd.outcome == 'success'
+      if: always()
       run: |
         log_response=$(curl -X GET \
             -H "ls-api-key: ${LOCALSTACK_API_KEY:-${{ inputs.localstack-api-key }}}" \

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -66,6 +66,7 @@ runs:
 
     - name: Create preview environment
       shell: bash
+      id: create-instance
       run: |
         autoLoadPod="${AUTO_LOAD_POD:-${{ inputs.auto-load-pod }}}"
         extensionAutoInstall="${EXTENSION_AUTO_INSTALL:-${{ inputs.extension-auto-install }}}"
@@ -113,7 +114,7 @@ runs:
         ${{ inputs.preview-cmd }}
 
     - name: Print logs of ephemeral instance
-      if: always()
+      if: ${{ !cancelled() && steps.create-instance.outcome == 'success' }}
       shell: bash
       run: |
         log_response=$(curl -X GET \


### PR DESCRIPTION
## Background
With @remotesynth and @HarshCasper working on the blog post for ephemeral instances and application previews, they have identified the need for getting logs of LocalStack, in case the deployment of their application (= preview-cmd) failed.
Debugging issues with a deployment on LocalStack without logs is basically impossible.

## Solution
This PR invokes the new endpoint to fetch logs of ephemeral instances after the preview-cmd is finished, and prints them.
