### PR TITLE
update artifacts GitHub actions to v4

### DIFF
--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -61,6 +61,8 @@ jobs:
             echo "Text not found in PR comments."
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
           
       # We want explicit shutdown
       - name: Shutdown ephemeral instance

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -18,6 +18,7 @@ jobs:
               "github-token": ${{ toJSON(secrets.GITHUB_TOKEN) }},
               "state-backend": "ephemeral",
               "state-action": "start",
+              "include-preview": "true",
               "skip-ephemeral-stop": "true",
               "preview-cmd": ${{ toJSON(env.PREVIEW_CMD) }},
               "lifetime": 5,
@@ -31,7 +32,7 @@ jobs:
             awslocal sqs create-queue --queue-name=test-queue
             echo "Deploy is done."
         
-      - name: Assertion step
+      - name: Assert mailhog is installed
         run: |
           sudo apt-get install jq jo
           response=$(curl ${AWS_ENDPOINT_URL}/_localstack/extensions/list)

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -18,6 +18,7 @@ jobs:
               "github-token": ${{ toJSON(secrets.GITHUB_TOKEN) }},
               "state-backend": "ephemeral",
               "state-action": "start",
+              "include-preview": "true",
               "skip-ephemeral-stop": "true",
               "preview-cmd": ${{ toJSON(env.PREVIEW_CMD) }},
               "lifetime": 5,

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -45,6 +45,22 @@ jobs:
             exit 1
           fi
 
+      - name: Check PR Comments for preview text
+        id: check-comments
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          TEXT_TO_FIND="Preview for this PR"
+          
+          # Fetch PR comments
+          comments=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/comments)
+
+          # Check if the specific text is in the comments
+          if echo "$comments" | jq -e --arg text "$TEXT_TO_FIND" '.[] | select(.body | contains($text))' > /dev/null; then
+            echo "Found the text in PR comments."
+          else
+            echo "Text not found in PR comments."
+            exit 1
+          fi
           
       # We want explicit shutdown
       - name: Shutdown ephemeral instance

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -18,7 +18,6 @@ jobs:
               "github-token": ${{ toJSON(secrets.GITHUB_TOKEN) }},
               "state-backend": "ephemeral",
               "state-action": "start",
-              "include-preview": "true",
               "skip-ephemeral-stop": "true",
               "preview-cmd": ${{ toJSON(env.PREVIEW_CMD) }},
               "lifetime": 5,

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
     - name: Download PR artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: pr
 

--- a/ephemeral/shutdown/action.yml
+++ b/ephemeral/shutdown/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Download PR artifact
       uses: actions/download-artifact@v4
       with:
-        name: pr
+        name: pr-id
 
     - name: Load the PR ID
       id: pr

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Download PR artifact
       uses: actions/download-artifact@v4
       with:
-        name: pr
+        name: pr-id
 
     - name: Setup preview name
       shell: bash
@@ -104,7 +104,7 @@ runs:
     - name: Upload preview instance URL
       uses: actions/upload-artifact@v4
       with:
-        name: pr
+        name: preview-instance-url
         path: ./ls-preview-url.txt
 
     - name: Run preview deployment

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -51,7 +51,7 @@ runs:
           }
 
     - name: Download PR artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: pr
 
@@ -102,7 +102,7 @@ runs:
         echo "AWS_ENDPOINT_URL=$endpointUrl" >> $GITHUB_ENV
 
     - name: Upload preview instance URL
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pr
         path: ./ls-preview-url.txt

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -40,6 +40,23 @@ runs:
       shell: bash
       run: echo "pr_id=$(<pr-id.txt)" >> $GITHUB_OUTPUT
 
+    - name: Download preview instance URL
+      id: get-preview-instance-url-artifact
+      if: inputs.include-preview
+      uses: actions/download-artifact@v4
+      with:
+        name: preview-instance-url
+
+    # If the above fails, try to get the latest pr artifact from the PR related workflows
+    - name: Download latest PR artifact
+      uses: dawidd6/action-download-artifact@v6
+      if: ${{ steps.get-preview-instance-url-artifact.outcome == 'failure' }}
+      with:
+        name: preview-instance-url
+        pr: ${{ github.event.pull_request.number }}
+        # Can be ID or workflow file name, if empty falls back to the latest successful run of the current workflow
+        workflow: ${{ env.PR_ARTIFACT_WORKFLOW }}
+
     - name: Load the Ephemeral Instance URL
       shell: bash
       if: inputs.include-preview

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -23,14 +23,14 @@ runs:
       uses: actions/download-artifact@v4
       continue-on-error: true
       with:
-        name: pr
+        name: pr-id
 
     # If the above fails, try to get the latest pr artifact from the PR related workflows
     - name: Download latest PR artifact
       uses: dawidd6/action-download-artifact@v6
       if: ${{ steps.get-pr-artifact.outcome == 'failure' }}
       with:
-        name: pr
+        name: pr-id
         pr: ${{ github.event.pull_request.number }}
         # Can be ID or workflow file name, if empty falls back to the latest successful run of the current workflow
         workflow: ${{ env.PR_ARTIFACT_WORKFLOW }}

--- a/finish/action.yml
+++ b/finish/action.yml
@@ -20,7 +20,7 @@ runs:
     # Try to get pr artifact from current workflow
     - name: Download current PR artifact
       id: get-pr-artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       continue-on-error: true
       with:
         name: pr

--- a/local/action.yml
+++ b/local/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Download current workflow's Local State artifact
       id: get-state-artifact
       if: ${{ inputs.action == 'load' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       continue-on-error: true
       with:
         name: ${{ inputs.name }}
@@ -48,7 +48,7 @@ runs:
         ACTION: "${{ inputs.action }}"
 
     - name: Upload LocalStack State
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: ${{ inputs.action == 'save' }}
       with:
         name: ${{ inputs.name }}

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Upload PR number
       uses: actions/upload-artifact@v4
       with:
-        name: pr
+        name: pr-id
         path: ./pr-id.txt
 
     - name: Create initial PR comment

--- a/prepare/action.yml
+++ b/prepare/action.yml
@@ -16,7 +16,7 @@ runs:
       run: echo ${{ github.event.number }} > ./pr-id.txt
 
     - name: Upload PR number
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: pr
         path: ./pr-id.txt


### PR DESCRIPTION
## Motivation 

GitHub is currently phasing out support for `actions/upload-artifact` and `actions/download-artifact` versions other than the latest major release v4: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

> Starting December 5, 2024, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).

This PR updates the the action to v4.

## Changes
Update the GitHub artifact action versions to v4 before the burn-down.