### PR TITLE
Pin the the jenseng/dynamic-uses transitive GH Action dependency to a hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       # We must hack the action call as remote to be able to use the relative paths
       # Could it break with different CWD? 🤔
       - name: Start LocalStack
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-
@@ -47,7 +47,7 @@ jobs:
       # We must hack the action call as remote to be able to use the relative paths
       # Could it break with different CWD? 🤔
       - name: Start LocalStack
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Start LocalStack
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-
@@ -94,7 +94,7 @@ jobs:
           awslocal sqs create-queue --queue-name test-queue
 
       - name: Save the Cloud Pod 
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-
@@ -114,7 +114,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Start LocalStack
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-
@@ -139,7 +139,7 @@ jobs:
           awslocal sqs delete-queue --queue-url $(awslocal sqs get-queue-url --queue-name test-queue --output text)
 
       - name: Save the State Artifact
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-

--- a/.github/workflows/ephemeral.yml
+++ b/.github/workflows/ephemeral.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Deploy Ephemeral Instance
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-
@@ -67,7 +67,7 @@ jobs:
       # We want explicit shutdown
       - name: Shutdown ephemeral instance
         if: ${{ always() }}
-        uses: jenseng/dynamic-uses@v1
+        uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
         with:
           uses: LocalStack/setup-localstack@${{ env.GH_ACTION_VERSION }}
           with: |-

--- a/action.yml
+++ b/action.yml
@@ -97,7 +97,7 @@ runs:
       shell: bash
 
     - name: Install tools
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       if: ${{ inputs.skip-startup == 'true' || inputs.state-backend == 'ephemeral' || inputs.state-action == 'save' }}
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/tools
@@ -107,7 +107,7 @@ runs:
           }
 
     - name: Start Localstack
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       if: ${{ inputs.skip-startup != 'true' && inputs.state-backend != 'ephemeral' && inputs.state-action != 'save' }}
       with:
         # now we can dynamically determine sub-action path 🥳
@@ -126,7 +126,7 @@ runs:
 
     - name: Create Ephemeral Instance
       if: ${{ inputs.state-action == 'start' && inputs.state-backend == 'ephemeral' }}
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/ephemeral/startup
         with: |-
@@ -141,7 +141,7 @@ runs:
     # Use different artifact from current workflow's by passing the workflow's id as WORKFLOW_ID env variable
     - name: Manage state
       if: ${{ inputs.state-action == 'save' || inputs.state-action == 'load' }}
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/${{ inputs.state-backend }}
         with: |-
@@ -152,7 +152,7 @@ runs:
 
     - name: Display Ephemeral Instance URL
       if: ${{ inputs.state-action == 'start' && inputs.state-backend == 'ephemeral' && (inputs.include-preview == 'true' || inputs.ci-project != '') }}
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/finish
         with: |-
@@ -164,7 +164,7 @@ runs:
     
     - name: Stop Ephemeral Instance
       if: ${{ (inputs.skip-ephemeral-stop == 'false' || inputs.state-action == 'stop') && inputs.state-backend == 'ephemeral' }}
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/ephemeral/shutdown
         with: |-

--- a/ephemeral/startup/action.yml
+++ b/ephemeral/startup/action.yml
@@ -42,7 +42,7 @@ runs:
 
     - name: Initial PR comment
       if: inputs.github-token
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/prepare
         with: |-

--- a/startup/action.yml
+++ b/startup/action.yml
@@ -50,7 +50,7 @@ runs:
       shell: bash
 
     - name: Install tools
-      uses: jenseng/dynamic-uses@v1
+      uses: jenseng/dynamic-uses@5175289a9a87978dcfcb9cf512b821d23b2a53eb # v1
       with:
         uses: ${{ env.GH_ACTION_ROOT }}/tools
         with: |-


### PR DESCRIPTION
With the [recent supply chain attack](https://arstechnica.com/information-technology/2025/03/supply-chain-attack-exposing-credentials-affects-23k-users-of-tj-actions/) on a popular GH Action, I noticed that this action has a transitive dependency on jenseng/dynamic-uses (which is a really clever chunk of code!).

[GitHub recommends](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) pinning to a SHA to protect against these sorts of attacks which is what this PR does.
