### PR TITLE
Allow specifying a custom Docker image name and registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ with:
 | `extension-auto-install` | Which extensions to install on startup of LocalStack (application preview) | `None`   | 
 | `github-token`          | Github token used to create PR comments |  |
 | `image-tag`        | Tag of the LocalStack Docker image to use                                        | `latest` |
+| `image-name`       | Full name of the LocalStack Docker image to use (e.g., `my.registry.com/localstack/localstack:latest`). Overrides `image-tag`. | `''`   |
 | `include-preview`          | Whether to include the created Ephemeral Instance URL in the PR comment | `false` |
 | `install-awslocal` | Whether to install the `awslocal` CLI into the build environment                 | `true`   |
 | `lifetime`         | How long an ephemeral instance should live                                       | 30       |

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Tag of the LocalStack Docker image to use'
     required: true
     default: 'latest'
+  image-name:
+    description: 'Full name of the LocalStack Docker image to use (e.g., my.registry.com/localstack/localstack:latest). Overrides image-tag.'
+    required: false
+    default: ''
   install-awslocal:
     description: 'Whether to install the `awslocal` CLI into the environment'
     required: true
@@ -117,6 +121,7 @@ runs:
         with: |-
           {
             "image-tag": ${{ toJSON(inputs.image-tag) }},
+            "image-name": ${{ toJSON(inputs.image-name) }},
             "install-awslocal": ${{ toJSON(inputs.install-awslocal) }},
             "use-pro": ${{ toJSON(inputs.use-pro) }},
             "configuration": ${{ toJSON(inputs.configuration) }},

--- a/startup/action.yml
+++ b/startup/action.yml
@@ -1,10 +1,15 @@
 name: 'Start up Localstack'
+description: 'Starts up LocalStack container'
 
 inputs:
   image-tag:
     description: 'Tag of the LocalStack Docker image to use'
     required: true
     default: 'latest'
+  image-name:
+    description: 'Full name of the LocalStack Docker image to use (e.g., my.registry.com/localstack/localstack:latest). Overrides image-tag.'
+    required: false
+    default: ''
   install-awslocal:
     description: 'Whether to install the `awslocal` CLI into the environment'
     required: true
@@ -60,14 +65,16 @@ runs:
 
     - name: Start LocalStack
       run: |
-        if [ "$USE_PRO" = true ]; then
-          if [ "x$LOCALSTACK_AUTH_TOKEN" = "x" -o "x$LOCALSTACK_API_KEY" = "x" ]; then
-            echo "WARNING: LocalStack API key not detected, please verify your configuration..."
+        if [ -z "$IMAGE_NAME" ]; then
+          if [ "$USE_PRO" = true ]; then
+            if [ "x$LOCALSTACK_AUTH_TOKEN" = "x" -o "x$LOCALSTACK_API_KEY" = "x" ]; then
+              echo "WARNING: LocalStack API key not detected, please verify your configuration..."
+            fi
+            CONFIGURATION="DNS_ADDRESS=127.0.0.1 ${CONFIGURATION}"
+            IMAGE_NAME="localstack/localstack-pro:${IMAGE_TAG}"
+          else
+            IMAGE_NAME="localstack/localstack:${IMAGE_TAG}"
           fi
-          CONFIGURATION="DNS_ADDRESS=127.0.0.1 ${CONFIGURATION}"
-          IMAGE_NAME="${IMAGE_NAME:-localstack/localstack-pro:${IMAGE_TAG}}"
-        else
-          IMAGE_NAME="${IMAGE_NAME:-localstack/localstack:${IMAGE_TAG}}"
         fi
 
         CONFIGURATION="IMAGE_NAME=${IMAGE_NAME} ${CONFIGURATION}"
@@ -82,6 +89,7 @@ runs:
       shell: bash
       env:
         IMAGE_TAG: ${{ inputs.image-tag }}
+        IMAGE_NAME: ${{ inputs.image-name }}
         INSTALL_AWSLOCAL: ${{ inputs.install-awslocal }}
         USE_PRO: ${{ inputs.use-pro }}
         CONFIGURATION: ${{ inputs.configuration }}


### PR DESCRIPTION
## Description

This pull request enhances the `setup-localstack` action by introducing a new input, `image-name`. This allows users to specify a full Docker image name, including a custom registry (e.g., `my.registry.com/localstack/localstack:latest`), rather than being limited to images hosted on Docker Hub, for when organizational policies restrict where images are allowed to be pulled from.

The action has been updated to prioritize the `image-name` input. If it is provided, it will be used directly to pull the LocalStack image (populating the `$IMAGE_NAME` environment variable). If it is not provided, the action will fall back to the existing behavior of constructing the image name using the `image-tag` input.

This change provides greater flexibility for users who manage their own Docker registries or use mirrors.

## Changes

*   Add the `image-name` input in [`action.yml`](action.yml) and pass it to the `startup` sub-action.
*   Update [`startup/action.yml`](startup/action.yml) to accept the `image-name` input and modify the startup logic to prioritize it over `image-tag` (directly populating `$IMAGE_NAME`).
*   Update the documentation in [`README.md`](README.md) to include the new `image-name` input.

## How to use

To use a custom image, simply add the `image-name` input to your workflow:

```yaml
- name: Start LocalStack from a custom registry
  uses: LocalStack/setup-localstack@v0.2.3
  with:
    image-name: 'my.registry.com/localstack/localstack-pro:latest'
  env:
    LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
```
```